### PR TITLE
feat: dynamic Umami event tracking across buttons, theme toggle & projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lenis": "^1.3.4",
     "lucide-react": "^0.525.0",
     "motion": "^12.23.0",
-    "next": "15.3.8",
+    "next": "^15.5.18",
     "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",
     "next-view-transitions": "^0.3.4",

--- a/src/app/blog/BlogPageClient.tsx
+++ b/src/app/blog/BlogPageClient.tsx
@@ -5,6 +5,7 @@ import Container from '@/components/common/Container';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { useHapticFeedback } from '@/hooks/use-haptic-feedback';
+import { useUmami } from '@/hooks/use-umami';
 import { BlogPostPreview } from '@/types/blog';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -32,6 +33,7 @@ export function BlogPageClient({
   const searchParams = useSearchParams();
   const router = useRouter();
   const { triggerHaptic, isMobile } = useHapticFeedback();
+  const { trackEvent } = useUmami();
 
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [filteredPosts, setFilteredPosts] = useState(initialPosts);
@@ -54,6 +56,15 @@ export function BlogPageClient({
     if (isMobile()) {
       triggerHaptic('light');
     }
+
+    trackEvent({
+      name: 'button_click',
+      data: {
+        buttonId: 'blog_tag_filter',
+        section: 'blog',
+        action: selectedTag === tag ? `clear:${tag}` : tag,
+      },
+    });
 
     if (selectedTag === tag) {
       setSelectedTag(null);

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -80,7 +80,15 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         <div className="space-y-12">
           {/* Back Button */}
           <div>
-            <Button variant="ghost" asChild className="group">
+            <Button
+              variant="ghost"
+              asChild
+              className="group"
+              track={{
+                name: 'button_click',
+                data: { buttonId: 'blog_back', section: 'blog_detail' },
+              }}
+            >
               <Link href="/blog" className="flex items-center space-x-2">
                 <ArrowLeft className="size-4" />
                 <span>Back to Blog</span>
@@ -105,7 +113,14 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           {/* Back to Blog CTA */}
           <div className="text-center">
             <Separator className="mb-8" />
-            <Button asChild size="lg">
+            <Button
+              asChild
+              size="lg"
+              track={{
+                name: 'button_click',
+                data: { buttonId: 'blog_view_all', section: 'blog_detail' },
+              }}
+            >
               <Link href="/blog">View All Blogs</Link>
             </Button>
           </div>

--- a/src/app/gears/page.tsx
+++ b/src/app/gears/page.tsx
@@ -1,11 +1,11 @@
 import Container from '@/components/common/Container';
+import { TrackedLink } from '@/components/common/TrackedLink';
 import Monitor from '@/components/svgs/devices/Monitor';
 import { Separator } from '@/components/ui/separator';
 import { devices, software, webExtensions } from '@/config/Gears';
 import { generateMetadata as getMetadata } from '@/config/Meta';
 import { ArrowUpRight, Puzzle } from 'lucide-react';
 import { Metadata } from 'next';
-import { Link } from 'next-view-transitions';
 import React from 'react';
 
 export const metadata: Metadata = {
@@ -71,9 +71,20 @@ export default function GearsPage() {
                     <span className="text-secondary text-sm">{index + 1}</span>
                   </div>
                   <h3 className="text-secondary ml-4 flex items-center gap-1 text-sm">
-                    <Link target="_blank" href={extension.href}>
+                    <TrackedLink
+                      target="_blank"
+                      href={extension.href}
+                      track={{
+                        name: 'external_link_click',
+                        data: {
+                          url: extension.href,
+                          text: extension.name,
+                          location: 'gears_extensions',
+                        },
+                      }}
+                    >
                       {extension.name}
-                    </Link>
+                    </TrackedLink>
                     <ArrowUpRight className="size-4" />
                   </h3>
                 </div>
@@ -100,9 +111,20 @@ export default function GearsPage() {
                     </span>
                   </div>
                   <h3 className="text-secondary ml-4 flex items-center gap-1 text-sm">
-                    <Link target="_blank" href={app.href}>
+                    <TrackedLink
+                      target="_blank"
+                      href={app.href}
+                      track={{
+                        name: 'external_link_click',
+                        data: {
+                          url: app.href,
+                          text: app.name,
+                          location: 'gears_software',
+                        },
+                      }}
+                    >
                       {app.name}
-                    </Link>
+                    </TrackedLink>
                     <ArrowUpRight className="size-4" />
                   </h3>
                 </div>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Container from '@/components/common/Container';
+import { TrackedLink } from '@/components/common/TrackedLink';
 import { ProjectContent } from '@/components/projects/ProjectContent';
 import { ProjectNavigation } from '@/components/projects/ProjectNavigation';
 import ArrowLeft from '@/components/svgs/ArrowLeft';
@@ -82,7 +83,15 @@ export default async function ProjectCaseStudyPage({
       <div className="space-y-12">
         {/* Back Button */}
         <div>
-          <Button variant="ghost" asChild className="group">
+          <Button
+            variant="ghost"
+            asChild
+            className="group"
+            track={{
+              name: 'button_click',
+              data: { buttonId: 'project_back', section: 'project_detail' },
+            }}
+          >
             <Link href="/projects" className="flex items-center space-x-2">
               <ArrowLeft className="size-4" />
               <span>Back to Projects</span>
@@ -114,7 +123,17 @@ export default async function ProjectCaseStudyPage({
                     key={project.slug}
                     className="group bg-card hover:bg-muted/50 rounded-lg border p-6 transition-colors"
                   >
-                    <Link href={`/projects/${project.slug}`}>
+                    <TrackedLink
+                      href={`/projects/${project.slug}`}
+                      track={{
+                        name: 'button_click',
+                        data: {
+                          buttonId: 'related_project',
+                          section: 'project_detail',
+                          action: project.slug,
+                        },
+                      }}
+                    >
                       <div className="space-y-3">
                         <div className="flex items-center gap-2">
                           <h3 className="group-hover:text-primary text-lg font-semibold">
@@ -158,7 +177,7 @@ export default async function ProjectCaseStudyPage({
                           )}
                         </div>
                       </div>
-                    </Link>
+                    </TrackedLink>
                   </div>
                 ))}
               </div>

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,11 +1,11 @@
 import Container from '@/components/common/Container';
+import { TrackedLink } from '@/components/common/TrackedLink';
 import CheckCircle from '@/components/svgs/CheckCircle';
 import { Separator } from '@/components/ui/separator';
 import { generateMetadata as getMetadata } from '@/config/Meta';
 import { settingsJson, steps } from '@/config/Setup';
 import { Download, ExternalLink, FileText } from 'lucide-react';
 import { Metadata } from 'next';
-import Link from 'next/link';
 import React from 'react';
 
 export const metadata: Metadata = {
@@ -65,10 +65,18 @@ export default function SetupPage() {
                 {step.content.map((item, index) => (
                   <div key={index} className="flex items-start gap-3">
                     {item.type === 'download' && (
-                      <Link
+                      <TrackedLink
                         href={item.href || '#'}
                         download
                         className="bg-muted/50 hover:bg-muted/70 flex w-full flex-col gap-3 rounded-lg border border-black/10 p-3 transition-colors sm:flex-row sm:items-center md:p-4 dark:border-white/10"
+                        track={{
+                          name: 'button_click',
+                          data: {
+                            buttonId: 'setup_download',
+                            section: 'setup',
+                            action: item.name,
+                          },
+                        }}
                       >
                         <Download className="text-muted-foreground size-4 flex-shrink-0" />
                         <div className="flex-1">
@@ -82,7 +90,7 @@ export default function SetupPage() {
                             {item.description}
                           </p>
                         </div>
-                      </Link>
+                      </TrackedLink>
                     )}
 
                     {item.type === 'instruction' && (

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -6,9 +6,9 @@ import {
   CardHeader,
 } from '@/components/ui/card';
 import { BlogPostPreview } from '@/types/blog';
-import { Link } from 'next-view-transitions';
 import Image from 'next/image';
 
+import { TrackedLink } from '../common/TrackedLink';
 import ArrowRight from '../svgs/ArrowRight';
 import Calender from '../svgs/Calender';
 
@@ -30,18 +30,38 @@ export function BlogCard({ post }: BlogCardProps) {
     <Card className="group h-full w-full overflow-hidden border-gray-100 p-0 shadow-none transition-all dark:border-gray-800">
       <CardHeader className="p-0">
         <div className="relative aspect-video overflow-hidden">
-          <Link href={`/blog/${slug}`}>
+          <TrackedLink
+            href={`/blog/${slug}`}
+            track={{
+              name: 'button_click',
+              data: {
+                buttonId: 'blog_card_image',
+                section: 'blog_card',
+                action: slug,
+              },
+            }}
+          >
             <Image src={image} alt={title} fill className="object-cover" />
-          </Link>
+          </TrackedLink>
         </div>
       </CardHeader>
       <CardContent>
         <div className="space-y-3">
-          <Link href={`/blog/${slug}`}>
+          <TrackedLink
+            href={`/blog/${slug}`}
+            track={{
+              name: 'button_click',
+              data: {
+                buttonId: 'blog_card_title',
+                section: 'blog_card',
+                action: slug,
+              },
+            }}
+          >
             <h3 className="group-hover:text-primary line-clamp-2 text-xl leading-tight font-semibold">
               {title}
             </h3>
-          </Link>
+          </TrackedLink>
           <p className="text-secondary mt-4 line-clamp-3">{description}</p>
         </div>
       </CardContent>
@@ -66,12 +86,20 @@ export function BlogCard({ post }: BlogCardProps) {
             >
               <Calender className="size-4" /> {formattedDate}
             </time>
-            <Link
+            <TrackedLink
               href={`/blog/${slug}`}
               className="text-secondary flex items-center justify-end gap-2 underline-offset-4 hover:underline"
+              track={{
+                name: 'button_click',
+                data: {
+                  buttonId: 'blog_card_read_more',
+                  section: 'blog_card',
+                  action: slug,
+                },
+              }}
             >
               Read More <ArrowRight className="size-4" />
-            </Link>
+            </TrackedLink>
           </div>
         </div>
       </CardFooter>

--- a/src/components/blog/CodeCopyButton.tsx
+++ b/src/components/blog/CodeCopyButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useUmami } from '@/hooks/use-umami';
 import React, { useState } from 'react';
 
 import Copied from '../svgs/Copied';
@@ -12,10 +13,15 @@ interface CodeCopyButtonProps {
 
 export function CodeCopyButton({ code }: CodeCopyButtonProps) {
   const [isCopied, setIsCopied] = useState(false);
+  const { trackEvent } = useUmami();
 
   const copyToClipboard = async () => {
     try {
       await navigator.clipboard.writeText(code);
+      trackEvent({
+        name: 'button_click',
+        data: { buttonId: 'copy_code', section: 'blog' },
+      });
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2000); // Reset after 2 seconds
     } catch (err) {

--- a/src/components/common/BackToTop.tsx
+++ b/src/components/common/BackToTop.tsx
@@ -27,6 +27,10 @@ export default function BackToTop() {
           size="icon"
           className="fixed right-10 bottom-4 z-50 bg-white hover:cursor-pointer md:right-20 dark:bg-black"
           onClick={handleClick}
+          track={{
+            name: 'button_click',
+            data: { buttonId: 'back_to_top', section: 'global' },
+          }}
         >
           <ArrowUp className="size-4" />
         </Button>

--- a/src/components/common/ChatBubble.tsx
+++ b/src/components/common/ChatBubble.tsx
@@ -14,6 +14,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { chatSuggestions } from '@/config/ChatPrompt';
 import { heroConfig } from '@/config/Hero';
 import { useHapticFeedback } from '@/hooks/use-haptic-feedback';
+import { useUmami } from '@/hooks/use-umami';
 import { cn } from '@/lib/utils';
 import React, { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -46,6 +47,7 @@ const ChatBubble: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const { triggerHaptic, isMobile } = useHapticFeedback();
+  const { trackEvent } = useUmami();
 
   // Auto-scroll to bottom when new messages are added
   useEffect(() => {
@@ -68,6 +70,10 @@ const ChatBubble: React.FC = () => {
     }
 
     const messageText = newMessage.trim();
+    trackEvent({
+      name: 'chat_message_sent',
+      data: { message: messageText, sender: 'user' },
+    });
     const userMessage: Message = {
       id: Date.now(),
       text: messageText,
@@ -113,6 +119,11 @@ const ChatBubble: React.FC = () => {
     if (isMobile()) {
       triggerHaptic('selection');
     }
+
+    trackEvent({
+      name: 'chat_message_sent',
+      data: { message: suggestion, sender: 'user' },
+    });
 
     setNewMessage(suggestion);
     // Auto-send the suggestion

--- a/src/components/common/FontSizeControls.tsx
+++ b/src/components/common/FontSizeControls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useHapticFeedback } from '@/hooks/use-haptic-feedback';
+import { useUmami } from '@/hooks/use-umami';
 import { Minus, Plus, Settings } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -16,6 +17,7 @@ import {
 export default function FontSizeControls() {
   const [fontSize, setFontSize] = useState<number>(16);
   const { triggerHaptic, isMobile } = useHapticFeedback();
+  const { trackEvent } = useUmami();
 
   // Load font size from localStorage on mount
   useEffect(() => {
@@ -49,6 +51,10 @@ export default function FontSizeControls() {
     if (isMobile()) {
       triggerHaptic('light');
     }
+    trackEvent({
+      name: 'button_click',
+      data: { buttonId: 'font_size_increase', section: 'font_controls' },
+    });
     updateFontSize(fontSize + 2);
   };
 
@@ -56,6 +62,10 @@ export default function FontSizeControls() {
     if (isMobile()) {
       triggerHaptic('light');
     }
+    trackEvent({
+      name: 'button_click',
+      data: { buttonId: 'font_size_decrease', section: 'font_controls' },
+    });
     updateFontSize(fontSize - 2);
   };
 
@@ -63,6 +73,10 @@ export default function FontSizeControls() {
     if (isMobile()) {
       triggerHaptic('medium');
     }
+    trackEvent({
+      name: 'button_click',
+      data: { buttonId: 'font_size_reset', section: 'font_controls' },
+    });
     updateFontSize(16);
   };
 

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -1,17 +1,23 @@
 import { navbarConfig } from '@/config/Navbar';
-import { Link } from 'next-view-transitions';
 import Image from 'next/image';
 import React from 'react';
 
 import Container from './Container';
 import { ThemeToggleButton } from './ThemeSwitch';
+import { TrackedLink } from './TrackedLink';
 
 export default function Navbar() {
   return (
     <Container className="sticky top-0 z-20 rounded-md py-4 backdrop-blur-sm">
       <div className="flex items-center justify-between px-6">
         <div className="flex items-baseline gap-4">
-          <Link href="/">
+          <TrackedLink
+            href="/"
+            track={{
+              name: 'button_click',
+              data: { buttonId: 'logo', section: 'navbar' },
+            }}
+          >
             <Image
               className="h-12 w-12 rounded-md border border-gray-200 bg-blue-300 transition-all duration-300 ease-in-out hover:scale-90 dark:bg-yellow-300"
               src={navbarConfig.logo.src}
@@ -19,16 +25,20 @@ export default function Navbar() {
               width={navbarConfig.logo.width}
               height={navbarConfig.logo.height}
             />
-          </Link>
+          </TrackedLink>
           <div className="flex items-center justify-center gap-4">
             {navbarConfig.navItems.map((item) => (
-              <Link
+              <TrackedLink
                 className="transition-all duration-300 ease-in-out hover:underline hover:decoration-2 hover:underline-offset-4"
                 key={item.label}
                 href={item.href}
+                track={{
+                  name: 'button_click',
+                  data: { buttonId: item.label, section: 'navbar' },
+                }}
               >
                 {item.label}
-              </Link>
+              </TrackedLink>
             ))}
           </div>
         </div>

--- a/src/components/common/ThemeSwitch.tsx
+++ b/src/components/common/ThemeSwitch.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useUmami } from '@/hooks/use-umami';
 import { cn } from '@/lib/utils';
 import { useTheme } from 'next-themes';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -19,7 +20,9 @@ export const useThemeToggle = ({
   blur?: boolean;
   gifUrl?: string;
 } = {}) => {
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
+
+  const { trackEvent } = useUmami();
 
   const [isDark, setIsDark] = useState(false);
 
@@ -29,13 +32,10 @@ export const useThemeToggle = ({
 
   const styleId = 'theme-transition-styles';
 
-  const updateStyles = useCallback((css: string, name: string) => {
+  const updateStyles = useCallback((css: string) => {
     if (typeof window === 'undefined') return;
 
     let styleElement = document.getElementById(styleId) as HTMLStyleElement;
-
-    console.log('style ELement', styleElement);
-    console.log('name', name);
 
     if (!styleElement) {
       styleElement = document.createElement('style');
@@ -44,21 +44,28 @@ export const useThemeToggle = ({
     }
 
     styleElement.textContent = css;
-
-    console.log('content updated');
   }, []);
 
   const toggleTheme = useCallback(() => {
     setIsDark(!isDark);
 
+    const from = isDark ? 'dark' : 'light';
+    const to = isDark ? 'light' : 'dark';
+    trackEvent({
+      name: 'theme_toggle',
+      data: { from, to, location: 'navbar' },
+    });
+
     const animation = createAnimation(variant, start, blur, gifUrl);
 
-    updateStyles(animation.css, animation.name);
+    updateStyles(animation.css);
 
     if (typeof window === 'undefined') return;
 
+    // Toggle from the resolved theme (via isDark), not `theme`, so the switch
+    // is correct even when `theme === 'system'` and matches the tracked from/to.
     const switchTheme = () => {
-      setTheme(theme === 'light' ? 'dark' : 'light');
+      setTheme(isDark ? 'light' : 'dark');
     };
 
     if (!document.startViewTransition) {
@@ -68,7 +75,6 @@ export const useThemeToggle = ({
 
     document.startViewTransition(switchTheme);
   }, [
-    theme,
     setTheme,
     variant,
     start,
@@ -77,6 +83,7 @@ export const useThemeToggle = ({
     updateStyles,
     isDark,
     setIsDark,
+    trackEvent,
   ]);
 
   const setCrazyLightTheme = useCallback(() => {
@@ -84,7 +91,7 @@ export const useThemeToggle = ({
 
     const animation = createAnimation(variant, start, blur, gifUrl);
 
-    updateStyles(animation.css, animation.name);
+    updateStyles(animation.css);
 
     if (typeof window === 'undefined') return;
 
@@ -105,7 +112,7 @@ export const useThemeToggle = ({
 
     const animation = createAnimation(variant, start, blur, gifUrl);
 
-    updateStyles(animation.css, animation.name);
+    updateStyles(animation.css);
 
     if (typeof window === 'undefined') return;
 

--- a/src/components/common/TrackedLink.tsx
+++ b/src/components/common/TrackedLink.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useUmami } from '@/hooks/use-umami';
+import type { AnalyticsEvent } from '@/types/analytics';
+import { Link } from 'next-view-transitions';
+import * as React from 'react';
+
+type LinkProps = React.ComponentProps<typeof Link>;
+
+/**
+ * Drop-in replacement for `next-view-transitions`' `Link` that fires an Umami
+ * event on click. Mirrors the `track` prop on the `Button` component so any
+ * link across the site — including those rendered inside server components —
+ * can opt into analytics with a single, type-safe prop, e.g.
+ * `track={{ name: 'external_link_click', data: { url, text, location } }}`.
+ */
+export function TrackedLink({
+  track,
+  onClick,
+  ...props
+}: LinkProps & { track?: AnalyticsEvent }) {
+  const { trackEvent } = useUmami();
+
+  return (
+    <Link
+      {...props}
+      onClick={(event) => {
+        if (track) {
+          trackEvent(track);
+        }
+        onClick?.(event);
+      }}
+    />
+  );
+}

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { useUmami } from '@/hooks/use-umami';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
@@ -56,6 +57,7 @@ type ContactFormValues = z.infer<typeof contactFormSchema>;
 
 export default function ContactForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { trackEvent } = useUmami();
 
   const form = useForm<ContactFormValues>({
     resolver: zodResolver(contactFormSchema),
@@ -81,16 +83,33 @@ export default function ContactForm() {
 
       const result = await response.json();
 
+      trackEvent({
+        name: 'form_submit',
+        data: { formId: 'contact', success: response.ok },
+      });
+
       if (response.ok) {
         toast.success('Message sent successfully!');
         form.reset();
       } else {
+        trackEvent({
+          name: 'form_error',
+          data: { formId: 'contact', errorType: 'request_failed' },
+        });
         toast.error(
           result.error || 'Failed to send message. Please try again.',
         );
       }
     } catch (error) {
       console.error('Error submitting form:', error);
+      trackEvent({
+        name: 'form_submit',
+        data: { formId: 'contact', success: false },
+      });
+      trackEvent({
+        name: 'form_error',
+        data: { formId: 'contact', errorType: 'network_error' },
+      });
       toast.error('Something went wrong. Please try again later.');
     } finally {
       setIsSubmitting(false);

--- a/src/components/landing/Blog.tsx
+++ b/src/components/landing/Blog.tsx
@@ -19,7 +19,13 @@ export default function Blog() {
         ))}
       </div>
       <div className="mt-8 flex justify-center">
-        <Button variant="outline">
+        <Button
+          variant="outline"
+          track={{
+            name: 'button_click',
+            data: { buttonId: 'show_all_blogs', section: 'blog' },
+          }}
+        >
           <Link href="/blog">Show all blogs</Link>
         </Button>
       </div>

--- a/src/components/landing/CTA.tsx
+++ b/src/components/landing/CTA.tsx
@@ -2,6 +2,7 @@
 
 import { ctaConfig } from '@/config/CTA';
 import { useHapticFeedback } from '@/hooks/use-haptic-feedback';
+import { useUmami } from '@/hooks/use-umami';
 import Cal, { getCalApi } from '@calcom/embed-react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
@@ -31,6 +32,7 @@ export default function CTA({
   preText = ctaConfig.preText,
 }: CallToActionProps) {
   const { triggerHaptic, isMobile } = useHapticFeedback();
+  const { trackEvent } = useUmami();
   const [showCalPopup, setShowCalPopup] = useState(false);
 
   useEffect(() => {
@@ -56,6 +58,10 @@ export default function CTA({
     if (isMobile()) {
       triggerHaptic('medium');
     }
+    trackEvent({
+      name: 'button_click',
+      data: { buttonId: 'book_meeting', section: 'cta', action: linkText },
+    });
     setShowCalPopup(true);
   };
 

--- a/src/components/landing/Experience.tsx
+++ b/src/components/landing/Experience.tsx
@@ -17,7 +17,13 @@ export default function Experience() {
         ))}
       </div>
       <div className="mt-8 flex justify-center">
-        <Button variant="outline">
+        <Button
+          variant="outline"
+          track={{
+            name: 'button_click',
+            data: { buttonId: 'show_all_experiences', section: 'experience' },
+          }}
+        >
           <Link href="/work-experience">Show all work experiences</Link>
         </Button>
       </div>

--- a/src/components/landing/Github.tsx
+++ b/src/components/landing/Github.tsx
@@ -161,7 +161,18 @@ export default function Github() {
             <p className="mb-4 text-sm">
               {githubConfig.errorState.description}
             </p>
-            <Button variant="outline" asChild>
+            <Button
+              variant="outline"
+              asChild
+              track={{
+                name: 'external_link_click',
+                data: {
+                  url: `https://github.com/${githubConfig.username}`,
+                  text: githubConfig.errorState.buttonText,
+                  location: 'github_section',
+                },
+              }}
+            >
               <Link
                 href={`https://github.com/${githubConfig.username}`}
                 className="inline-flex items-center gap-2"

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import Container from '../common/Container';
 import Skill from '../common/Skill';
+import { TrackedLink } from '../common/TrackedLink';
 import CV from '../svgs/CV';
 import Chat from '../svgs/Chat';
 import { Button } from '../ui/button';
@@ -84,6 +85,10 @@ export default function Hero() {
                 button.variant === 'outline' && 'inset-shadow-indigo-500',
                 button.variant === 'default' && 'inset-shadow-indigo-500',
               )}
+              track={{
+                name: 'button_click',
+                data: { buttonId: button.text, section: 'hero' },
+              }}
             >
               {IconComponent && <IconComponent />}
               <Link href={button.href}>{button.text}</Link>
@@ -97,13 +102,21 @@ export default function Hero() {
         {socialLinks.map((link) => (
           <Tooltip key={link.name} delayDuration={0}>
             <TooltipTrigger asChild>
-              <Link
+              <TrackedLink
                 href={link.href}
                 key={link.name}
                 className="text-secondary flex items-center gap-2"
+                track={{
+                  name: 'external_link_click',
+                  data: {
+                    url: link.href,
+                    text: link.name,
+                    location: 'hero_social',
+                  },
+                }}
               >
                 <span className="size-6">{link.icon}</span>
-              </Link>
+              </TrackedLink>
             </TooltipTrigger>
             <TooltipContent>
               <p>{link.name}</p>

--- a/src/components/landing/Journey.tsx
+++ b/src/components/landing/Journey.tsx
@@ -1,10 +1,10 @@
 import { journeyItems } from '@/config/Journey';
 import { ArrowRight } from 'lucide-react';
-import { Link } from 'next-view-transitions';
 import React from 'react';
 
 import Container from '../common/Container';
 import SectionHeading from '../common/SectionHeading';
+import { TrackedLink } from '../common/TrackedLink';
 import { Card } from '../ui/card';
 
 export default function Journey() {
@@ -13,7 +13,19 @@ export default function Journey() {
       <SectionHeading subHeading="My" heading="Journey" />
       <div className="mt-8 flex flex-col gap-4">
         {journeyItems.map((item) => (
-          <Link className="group" href={item.href} key={item.name}>
+          <TrackedLink
+            className="group"
+            href={item.href}
+            key={item.name}
+            track={{
+              name: 'button_click',
+              data: {
+                buttonId: item.name,
+                section: 'journey',
+                action: item.href,
+              },
+            }}
+          >
             <Card className="flex flex-row items-center justify-between gap-4 px-4 py-2">
               <div className="bg-muted flex items-center justify-center rounded-md p-2">
                 {(() => {
@@ -31,7 +43,7 @@ export default function Journey() {
               </div>
               <ArrowRight className="hidden size-4 transition-all duration-300 group-hover:block" />
             </Card>
-          </Link>
+          </TrackedLink>
         ))}
       </div>
     </Container>

--- a/src/components/landing/Projects.tsx
+++ b/src/components/landing/Projects.tsx
@@ -16,7 +16,13 @@ export default function Projects() {
 
       <ProjectList className="mt-8" projects={projects.slice(0, 4)} />
       <div className="mt-8 flex justify-center">
-        <Button variant="outline">
+        <Button
+          variant="outline"
+          track={{
+            name: 'button_click',
+            data: { buttonId: 'show_all_projects', section: 'projects' },
+          }}
+        >
           <Link href="/projects">Show all projects</Link>
         </Button>
       </div>

--- a/src/components/landing/Setup.tsx
+++ b/src/components/landing/Setup.tsx
@@ -1,9 +1,9 @@
 import { ArrowRight } from 'lucide-react';
-import { Link } from 'next-view-transitions';
 import React from 'react';
 
 import Container from '../common/Container';
 import SectionHeading from '../common/SectionHeading';
+import { TrackedLink } from '../common/TrackedLink';
 import Code from '../svgs/Code';
 import Gear from '../svgs/Gear';
 import { Card } from '../ui/card';
@@ -29,7 +29,15 @@ export default function Setup() {
       <SectionHeading subHeading="Development" heading="Setup" />
       <div className="mt-8 flex flex-col gap-4">
         {setup.map((item) => (
-          <Link className="group" href={item.href} key={item.name}>
+          <TrackedLink
+            className="group"
+            href={item.href}
+            key={item.name}
+            track={{
+              name: 'button_click',
+              data: { buttonId: item.name, section: 'setup' },
+            }}
+          >
             <Card className="flex flex-row items-center justify-between gap-4 px-4 py-2">
               <div className="bg-muted flex items-center justify-center rounded-md p-2">
                 {item.icon}
@@ -42,7 +50,7 @@ export default function Setup() {
               </div>
               <ArrowRight className="hidden size-4 transition-all duration-300 group-hover:block" />
             </Card>
-          </Link>
+          </TrackedLink>
         ))}
       </div>
     </Container>

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -12,6 +12,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { useUmami } from '@/hooks/use-umami';
+import type { AnalyticsEventData } from '@/types/analytics';
 import { type Project } from '@/types/project';
 import { Link } from 'next-view-transitions';
 import Image from 'next/image';
@@ -29,6 +31,27 @@ interface ProjectCardProps {
 
 export function ProjectCard({ project }: ProjectCardProps) {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+  const { trackEvent } = useUmami();
+
+  // Stable, human-readable id derived from the project's details route, e.g.
+  // '/projects/sleek-portfolio' -> 'sleek-portfolio'. Keeps every project
+  // uniquely identifiable in the dashboard with no per-project config.
+  const projectId =
+    project.projectDetailsPageSlug.split('/').filter(Boolean).pop() ??
+    project.title;
+
+  const trackProject = (
+    action: AnalyticsEventData['project_click']['action'],
+  ) =>
+    trackEvent({
+      name: 'project_click',
+      data: {
+        projectId,
+        projectTitle: project.title,
+        action,
+        location: 'project_card',
+      },
+    });
 
   return (
     <Card className="group h-full w-full overflow-hidden border-gray-100 p-0 shadow-none transition-all dark:border-gray-800">
@@ -45,7 +68,10 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
               <DialogTrigger asChild>
                 <div className="absolute inset-0 flex cursor-pointer items-center justify-center bg-black/20 opacity-0 transition-opacity duration-300 group-hover:opacity-100 hover:backdrop-blur-xs">
-                  <button className="flex size-16 items-center justify-center rounded-full bg-white/20 backdrop-blur-sm transition-colors duration-200 group-hover:cursor-pointer hover:bg-white/30">
+                  <button
+                    className="flex size-16 items-center justify-center rounded-full bg-white/20 backdrop-blur-sm transition-colors duration-200 group-hover:cursor-pointer hover:bg-white/30"
+                    onClick={() => trackProject('play_video')}
+                  >
                     <PlayCircle />
                   </button>
                 </div>
@@ -71,7 +97,10 @@ export function ProjectCard({ project }: ProjectCardProps) {
         <div className="space-y-4">
           {/* Project Header - Title and Icons */}
           <div className="flex items-center justify-between gap-4">
-            <Link href={project.projectDetailsPageSlug}>
+            <Link
+              href={project.projectDetailsPageSlug}
+              onClick={() => trackProject('view_details')}
+            >
               <h3 className="group-hover:text-primary text-xl leading-tight font-semibold hover:cursor-pointer">
                 {project.title}
               </h3>
@@ -83,6 +112,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
                     className="text-secondary hover:text-primary flex size-6 items-center justify-center transition-colors"
                     href={project.link}
                     target="_blank"
+                    onClick={() => trackProject('visit_website')}
                   >
                     <Website />
                   </Link>
@@ -98,6 +128,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
                       className="text-secondary hover:text-primary flex size-6 items-center justify-center transition-colors"
                       href={project.github}
                       target="_blank"
+                      onClick={() => trackProject('visit_github')}
                     >
                       <Github />
                     </Link>
@@ -160,6 +191,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
           <Link
             href={project.projectDetailsPageSlug}
             className="text-secondary hover:text-primary flex items-center gap-2 text-sm underline-offset-4 transition-colors hover:underline"
+            onClick={() => trackProject('view_details')}
           >
             View Details <ArrowRight className="size-4" />
           </Link>

--- a/src/components/projects/ProjectContent.tsx
+++ b/src/components/projects/ProjectContent.tsx
@@ -112,7 +112,17 @@ export function ProjectContent({ frontmatter, content }: ProjectContentProps) {
           {/* Action Buttons */}
           <div className="flex flex-wrap gap-3">
             {live && (
-              <Button asChild>
+              <Button
+                asChild
+                track={{
+                  name: 'external_link_click',
+                  data: {
+                    url: live,
+                    text: 'Live Demo',
+                    location: 'project_detail',
+                  },
+                }}
+              >
                 <Link
                   href={live}
                   target="_blank"
@@ -125,7 +135,18 @@ export function ProjectContent({ frontmatter, content }: ProjectContentProps) {
               </Button>
             )}
             {github && (
-              <Button variant="outline" asChild>
+              <Button
+                variant="outline"
+                asChild
+                track={{
+                  name: 'external_link_click',
+                  data: {
+                    url: github,
+                    text: 'Source Code',
+                    location: 'project_detail',
+                  },
+                }}
+              >
                 <Link
                   href={github}
                   target="_blank"

--- a/src/components/projects/ProjectNavigation.tsx
+++ b/src/components/projects/ProjectNavigation.tsx
@@ -27,6 +27,14 @@ export function ProjectNavigation({ previous, next }: ProjectNavigationProps) {
               variant="outline"
               asChild
               className="group h-auto w-full justify-start p-4 text-left"
+              track={{
+                name: 'button_click',
+                data: {
+                  buttonId: 'project_nav_previous',
+                  section: 'project_detail',
+                  action: previous.slug,
+                },
+              }}
             >
               <Link href={`/projects/${previous.slug}`}>
                 <div className="flex items-center gap-3">
@@ -52,6 +60,14 @@ export function ProjectNavigation({ previous, next }: ProjectNavigationProps) {
               variant="outline"
               asChild
               className="group h-auto w-full justify-end p-4 text-right"
+              track={{
+                name: 'button_click',
+                data: {
+                  buttonId: 'project_nav_next',
+                  section: 'project_detail',
+                  action: next.slug,
+                },
+              }}
             >
               <Link href={`/projects/${next.slug}`}>
                 <div className="flex items-center gap-3">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useHapticFeedback } from '@/hooks/use-haptic-feedback';
+import { useUmami } from '@/hooks/use-umami';
 import { cn } from '@/lib/utils';
+import type { AnalyticsEvent } from '@/types/analytics';
 import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps, cva } from 'class-variance-authority';
 import * as React from 'react';
@@ -43,17 +45,28 @@ function Button({
   size,
   asChild = false,
   onClick,
+  track,
   ...props
 }: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
+    /**
+     * Optional analytics event fired on click. Lets any button across the site
+     * opt into tracking with a single prop, e.g.
+     * `track={{ name: 'button_click', data: { buttonId: 'resume_download' } }}`.
+     */
+    track?: AnalyticsEvent;
   }) {
   const Comp = asChild ? Slot : 'button';
   const { triggerHaptic, isMobile } = useHapticFeedback();
+  const { trackEvent } = useUmami();
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (isMobile()) {
       triggerHaptic('light');
+    }
+    if (track) {
+      trackEvent(track);
     }
     onClick?.(event);
   };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -15,8 +15,11 @@ function ScrollArea({
 
   React.useEffect(() => {
     type WindowWithLenis = Window & { lenis?: Lenis };
-    if (typeof window !== 'undefined' && (window as WindowWithLenis).lenis) {
-      setLenisInstance((window as WindowWithLenis).lenis!);
+    if (
+      typeof window !== 'undefined' &&
+      (window as unknown as WindowWithLenis).lenis
+    ) {
+      setLenisInstance((window as unknown as WindowWithLenis).lenis!);
     }
   }, []);
 

--- a/src/hooks/use-umami.ts
+++ b/src/hooks/use-umami.ts
@@ -7,31 +7,29 @@ declare global {
   interface Window {
     umami?: {
       track: (
-        event: AnalyticsEvent['name'],
-        data: AnalyticsEvent['data'],
+        eventName: string,
+        eventData?: Record<string, string | number | boolean>,
       ) => void;
     };
   }
 }
 
 /**
- * Hook for tracking events with Umami Analytics
- * @example Usage
- * ```tsx
- * function MyComponent() {
- *   const { trackEvent } = useUmami()
+ * Hook for tracking events with Umami Analytics.
  *
- *   const handleClick = () => {
- *     trackEvent({
- *       name: 'button_click',
- *       data: {
- *         buttonId: 'hero_cta',
- *         section: 'hero'
- *       }
- *     })
- *   }
- *   return <button onClick={handleClick}>Click Me</button>
- * }
+ * `trackEvent` is type-safe: the `data` payload is constrained by the `name`
+ * via the `AnalyticsEvent` discriminated union, so the wrong payload for an
+ * event is a compile error. Calls are no-ops (not errors) when the Umami
+ * script hasn't loaded yet — e.g. blocked by an ad blocker or still loading.
+ *
+ * @example
+ * ```tsx
+ * const { trackEvent } = useUmami();
+ *
+ * trackEvent({
+ *   name: 'button_click',
+ *   data: { buttonId: 'hero_cta', section: 'hero' },
+ * });
  * ```
  */
 export function useUmami() {

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,17 +1,14 @@
-export type AnalyticsEvent = {
-  name:
-    | 'page_view'
-    | 'button_click'
-    | 'form_submit'
-    | 'form_error'
-    | 'content_view'
-    | 'chat_message_sent'
-    | 'external_link_click';
-  data: {
-    [key: string]: string | boolean | number;
-  };
-};
-
+/**
+ * Single source of truth for every analytics event the site can emit.
+ *
+ * To add a new event, add one entry here. The event-name union, the
+ * discriminated `AnalyticsEvent` type, and the typing of `useUmami().trackEvent`
+ * all derive from this map automatically, so the rest of the app stays type-safe
+ * and the taxonomy scales without touching the hook.
+ *
+ * Umami's `track(name, data)` only accepts flat primitive values, so every
+ * shape below must stay flat (string | number | boolean).
+ */
 export type AnalyticsEventData = {
   page_view: {
     path: string;
@@ -21,6 +18,23 @@ export type AnalyticsEventData = {
     buttonId: string;
     section?: string;
     action?: string;
+  };
+  theme_toggle: {
+    from: 'light' | 'dark';
+    to: 'light' | 'dark';
+    location?: string;
+  };
+  /**
+   * Fired for any interaction with a specific project. `projectId` keeps each
+   * project uniquely identifiable in the dashboard, and `action` distinguishes
+   * how the project was engaged with. New projects are tracked automatically —
+   * no per-project code required.
+   */
+  project_click: {
+    projectId: string;
+    projectTitle: string;
+    action: 'view_details' | 'visit_website' | 'visit_github' | 'play_video';
+    location?: string;
   };
   form_submit: {
     formId: string;
@@ -46,3 +60,17 @@ export type AnalyticsEventData = {
     location: string;
   };
 };
+
+/** Union of all valid event names, e.g. 'button_click' | 'theme_toggle' | ... */
+export type AnalyticsEventName = keyof AnalyticsEventData;
+
+/**
+ * Discriminated union pairing each event name with its matching data shape.
+ * Derived from `AnalyticsEventData` so the two can never drift apart.
+ */
+export type AnalyticsEvent = {
+  [Name in AnalyticsEventName]: {
+    name: Name;
+    data: AnalyticsEventData[Name];
+  };
+}[AnalyticsEventName];


### PR DESCRIPTION
Addresses the tracking enhancement:
- typed useUmami hook, with a `track` prop on Button and a new TrackedLink so any button or link opts in with one prop
- theme toggle now records from/to and toggles correctly from the system theme
- per-project click tracking (view details, website, github, play video)
- click tracking across nav, hero, blog, contact form and chat

Also includes the next 15.5.18 bump already in the tree and a scroll-area type-cast fix so the build passes.

<img width="1278" height="804" alt="image" src="https://github.com/user-attachments/assets/4c651b7d-6c31-4c0b-af34-1494669b0e0f" />
